### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/docker/docker-compose/kafka/docker-compose.yml
+++ b/docker/docker-compose/kafka/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kafka-0:
-    image: bitnami/kafka:4.0
+    image: soldevelo/kafka:4.0
     hostname: kafka-0
     ports:
       - 9092:9092
@@ -27,7 +27,7 @@ services:
       KAFKA_HEAP_OPTS: -Xmx512M -Xms256M
       
   kafka-1:
-    image: bitnami/kafka:4.0
+    image: soldevelo/kafka:4.0
     hostname: kafka-1
     ports:
       - 9192:9092
@@ -54,7 +54,7 @@ services:
       KAFKA_HEAP_OPTS: -Xmx512M -Xms256M
 
   kafka-2:
-    image: bitnami/kafka:4.0
+    image: soldevelo/kafka:4.0
     hostname: kafka-2
     ports:
       - 9292:9092


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/kafka:4.0` → [`soldevelo/kafka:4.0`](https://hub.docker.com/r/soldevelo/kafka)